### PR TITLE
Using ::class for all test classes

### DIFF
--- a/tests/AbstractStrategyTest.php
+++ b/tests/AbstractStrategyTest.php
@@ -4,11 +4,15 @@ namespace WyriHaximus\CpuCoreDetector\Tests;
 
 use ApiClients\Tools\TestUtilities\TestCase;
 
+use React\Promise\PromiseInterface;
+
+use WyriHaximus\CpuCoreDetector\StrategyInterface;
+
 abstract class AbstractStrategyTest extends TestCase
 {
     public function testImplementsStrategyInterface(): void
     {
-        $this->assertInstanceOf('WyriHaximus\CpuCoreDetector\StrategyInterface', $this->getStrategy());
+        $this->assertInstanceOf(StrategyInterface::class, $this->getStrategy());
     }
 
     public function testSupportsCurrentOS(): void
@@ -18,7 +22,7 @@ abstract class AbstractStrategyTest extends TestCase
 
     public function testExecute(): void
     {
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $this->getStrategy()->execute());
+        $this->assertInstanceOf(PromiseInterface::class, $this->getStrategy()->execute());
     }
 
     abstract protected function getStrategy();

--- a/tests/CollectionsTest.php
+++ b/tests/CollectionsTest.php
@@ -4,6 +4,8 @@ namespace WyriHaximus\CpuCoreDetector\Tests;
 
 use ApiClients\Tools\TestUtilities\TestCase;
 
+use React\EventLoop\LoopInterface;
+
 use WyriHaximus\CpuCoreDetector\Collections;
 
 /**
@@ -13,7 +15,7 @@ class CollectionsTest extends TestCase
 {
     public function testCollections(): void
     {
-        $loop = $this->prophesize('React\EventLoop\LoopInterface')->reveal();
+        $loop = $this->prophesize(LoopInterface::class)->reveal();
         $detectors = \WyriHaximus\CpuCoreDetector\getDefaultDetectors($loop);
         $counters = \WyriHaximus\CpuCoreDetector\getDefaultCounters($loop);
         $affinities = \WyriHaximus\CpuCoreDetector\getDefaultAffinities($loop);

--- a/tests/Detector/AbstractDetectorTest.php
+++ b/tests/Detector/AbstractDetectorTest.php
@@ -2,13 +2,15 @@
 
 namespace WyriHaximus\CpuCoreDetector\Tests\Detector;
 
+use WyriHaximus\CpuCoreDetector\DetectorInterface;
+
 use WyriHaximus\CpuCoreDetector\Tests\Core\AbstractCoreTest;
 
 abstract class AbstractDetectorTest extends AbstractCoreTest
 {
     public function testImplementsDetectorInterface(): void
     {
-        $this->assertInstanceOf('WyriHaximus\CpuCoreDetector\DetectorInterface', $this->getStrategy());
+        $this->assertInstanceOf(DetectorInterface::class, $this->getStrategy());
     }
 
     public function testGetCommandName(): void

--- a/tests/Detector/HashTest.php
+++ b/tests/Detector/HashTest.php
@@ -2,6 +2,7 @@
 
 namespace WyriHaximus\CpuCoreDetector\Tests\Detector;
 
+use React\EventLoop\LoopInterface;
 use WyriHaximus\CpuCoreDetector\Detector\Hash;
 use WyriHaximus\CpuCoreDetector\Tests\AbstractStrategyTest;
 
@@ -12,6 +13,6 @@ class HashTest extends AbstractStrategyTest
 {
     protected function getStrategy()
     {
-        return new Hash($this->prophesize('React\EventLoop\LoopInterface')->reveal());
+        return new Hash($this->prophesize(LoopInterface::class)->reveal());
     }
 }

--- a/tests/DetectorCollectionTest.php
+++ b/tests/DetectorCollectionTest.php
@@ -6,6 +6,7 @@ use ApiClients\Tools\TestUtilities\TestCase;
 use WyriHaximus\CpuCoreDetector\Core\CountCollection;
 use WyriHaximus\CpuCoreDetector\Core\CountInterface;
 use WyriHaximus\CpuCoreDetector\DetectorCollection;
+use WyriHaximus\CpuCoreDetector\DetectorInterface;
 
 /**
  * @internal
@@ -16,14 +17,14 @@ final class DetectorCollectionTest extends TestCase
     {
         $counterUnSupported = $this->prophesize(CountInterface::class);
         $counterUnSupported->supportsCurrentOS()->shouldBeCalled()->willReturn(false);
-        $counterSupported = $this->prophesize('WyriHaximus\CpuCoreDetector\Core\CountInterface');
+        $counterSupported = $this->prophesize(CountInterface::class);
         $counterSupported->supportsCurrentOS()->shouldBeCalled()->willReturn(true);
         $counterSupported->getCommandName()->shouldBeCalled()->willReturn('');
         //$counterSupported->execute()->shouldBeCalled()->willReturn(1);
 
-        $detectorUnSupported = $this->prophesize('WyriHaximus\CpuCoreDetector\DetectorInterface');
+        $detectorUnSupported = $this->prophesize(DetectorInterface::class);
         $detectorUnSupported->supportsCurrentOS()->shouldBeCalled()->willReturn(false);
-        $detectorSupported = $this->prophesize('WyriHaximus\CpuCoreDetector\DetectorInterface');
+        $detectorSupported = $this->prophesize(DetectorInterface::class);
         $detectorSupported->supportsCurrentOS()->shouldBeCalled()->willReturn(true);
         $detectorSupported->execute('')->shouldBeCalled()->willReturn(1);
 


### PR DESCRIPTION
# Changed log
- Using the `::class` magic method approach for all classes in `tests` folder because of consistency.